### PR TITLE
승인대기 중인 관리자 승인/거부 처리

### DIFF
--- a/src/main/java/org/codingtext/admin/controller/AuthController.java
+++ b/src/main/java/org/codingtext/admin/controller/AuthController.java
@@ -1,7 +1,9 @@
 package org.codingtext.admin.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.codingtext.admin.dto.LoginRequest;
+import org.codingtext.admin.dto.PermitRequest;
 import org.codingtext.admin.dto.SignupRequest;
 import org.codingtext.admin.service.AuthService;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -27,5 +30,12 @@ public class AuthController {
     @GetMapping("/none")
     public ResponseEntity<?> findNoneAccount() {
         return ResponseEntity.ok(authService.findNoneAccount());
+    }
+
+    @PostMapping("/permit")
+    public ResponseEntity<?> permitAdmin(
+            @RequestHeader("AdminId") long adminId,
+            @RequestBody PermitRequest permitRequest) {
+        return ResponseEntity.ok(authService.processAdminRequest(adminId, permitRequest));
     }
 }

--- a/src/main/java/org/codingtext/admin/dto/PermitRequest.java
+++ b/src/main/java/org/codingtext/admin/dto/PermitRequest.java
@@ -1,0 +1,10 @@
+package org.codingtext.admin.dto;
+import lombok.*;
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PermitRequest {
+    private Long adminId;
+    private Boolean isPermit;
+}

--- a/src/main/java/org/codingtext/admin/dto/PermitResponse.java
+++ b/src/main/java/org/codingtext/admin/dto/PermitResponse.java
@@ -1,0 +1,10 @@
+package org.codingtext.admin.dto;
+import lombok.*;
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PermitResponse {
+    private Long adminId;
+    private String message;
+}

--- a/src/main/java/org/codingtext/admin/jwt/JwtProvider.java
+++ b/src/main/java/org/codingtext/admin/jwt/JwtProvider.java
@@ -28,9 +28,10 @@ public class JwtProvider {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String createToken(String email) {
+    public String createToken(long id, String email) {
         return Jwts.builder()
-                .subject(email)
+                .subject(String.valueOf(id))
+                .claim("email", email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
                 .signWith(secretKey)


### PR DESCRIPTION
## #️연관된 티켓 넘버
> CT-148

## 작업 내용
승인대기중인 관리자를 승인 혹은 거부하는 로직

root계정에서만 해당 로직을 처리할 수 있도록 하였으며 승인 처리되었으면 GENERAL로 role 변경, 거부 처리되었으면 대기중인 관리자를 db에서 삭제하도록 처리

## 스크린샷

## 체크리스트

## Reference (Wiki)